### PR TITLE
Addresses #81

### DIFF
--- a/spec/ttml-ww-profiles.html
+++ b/spec/ttml-ww-profiles.html
@@ -829,7 +829,8 @@ ittp:progressivelyDecodable
             <td><code>#cellResolution</code></td>
 
             <td>permitted</td>
-<td></td>
+<td>If the <a>Document Instance</a> includes any length value that uses the <code>c</code> expression,
+            <code>ttp:cellResolution</code> SHOULD be present on the <code>tt</code> element.</td>
           </tr>
 
           <tr>


### PR DESCRIPTION
Resolves #81 

Recommends `ttp:cellResolution` on \<tt\> if `c` is used in the Document