### PR TITLE
Add note indicating line padding can only use 'c' units (#110) 

### DIFF
--- a/spec/ttml-ww-profiles.html
+++ b/spec/ttml-ww-profiles.html
@@ -55,6 +55,7 @@ table.syntax { border: 0px solid black; width: 85%; border-collapse: collapse }
 	.note {font-size:small}
 	.equation {text-indent: 10%;}
 	.example {font-size: small}
+	.inline-note {font-size: small}
   </style>
 </head>
 
@@ -1823,8 +1824,9 @@ be present on the <code>tt</code> element.</td>
 						</ul>
 						</p>
 						
+						<p class="inline-note">NOTE: The <code>ebutts:linePadding</code> attribute only supports "c" length units.</p>
 						
-						</td>
+			</td>
           </tr>
 
           <tr>


### PR DESCRIPTION
Resolves #110 