### PR TITLE
Nested span feature prohibition is redundant in image profile (#113)

### DIFF
--- a/spec/ttml-ww-profiles.html
+++ b/spec/ttml-ww-profiles.html
@@ -2101,7 +2101,7 @@ be present on the <code>tt</code> element.</td>
 
              <td>prohibited</td>
 						
-						<td></td>
+			<td><p class="inline-note">NOTE: The prohibition of <code>span</code> elements by this profile implies the prohibition of this feature.<p></td>
           </tr>
 
           <tr>


### PR DESCRIPTION
Resolves #113