### PR TITLE
Addresses #148 (Change profile signalling in files with ebu-tt-d extensions)

### DIFF
--- a/testsuite/linePadding/linePadding1.ttml
+++ b/testsuite/linePadding/linePadding1.ttml
@@ -1,12 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<tt xml:lang="en"
-    xmlns="http://www.w3.org/ns/ttml"
-    xmlns:ttm="http://www.w3.org/ns/ttml#metadata" 
-    xmlns:tts="http://www.w3.org/ns/ttml#styling"
-    xmlns:ttp="http://www.w3.org/ns/ttml#parameter" ttp:profile="http://www.w3.org/ns/ttml/profile/imsc1/text"
-    xmlns:ebutts="urn:ebu:tt:style"
-    ttp:timeBase="media">
+<tt xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xmlns="http://www.w3.org/ns/ttml" xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+ xmlns:tts="http://www.w3.org/ns/ttml#styling" xmlns:ttm="http://www.w3.org/ns/ttml#metadata"
+ xmlns:ebutts="urn:ebu:tt:style" xml:lang="en" ttp:timeBase="media" xmlns:ebuttm="urn:ebu:tt:metadata" >
     <head>
+        <metadata>
+            <ebuttm:documentMetadata>
+                <ebuttm:conformsToStandard>urn:ebu:tt:distribution:2014-01</ebuttm:conformsToStandard>
+                <ebuttm:conformsToStandard>http://www.w3.org/ns/ttml/profile/imsc1/text</ebuttm:conformsToStandard>
+            </ebuttm:documentMetadata>
+        </metadata>
         <styling>
             <style xml:id="baseStyle" tts:color="#FFFFFF" tts:textAlign="center"/>
             <style xml:id="blackBackground" tts:backgroundColor="#000000"/>

--- a/testsuite/multiRowAlign/multiRowAlign1.ttml
+++ b/testsuite/multiRowAlign/multiRowAlign1.ttml
@@ -1,12 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<tt xml:lang="en" 
-	xmlns="http://www.w3.org/ns/ttml" 
-	xmlns:ttm="http://www.w3.org/ns/ttml#metadata" 
-	xmlns:tts="http://www.w3.org/ns/ttml#styling"
-        xmlns:ttp="http://www.w3.org/ns/ttml#parameter" ttp:profile="http://www.w3.org/ns/ttml/profile/imsc1/text"
-	xmlns:ebutts="urn:ebu:tt:style"
-	ttp:timeBase="media">
+<tt xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xmlns="http://www.w3.org/ns/ttml" xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+ xmlns:tts="http://www.w3.org/ns/ttml#styling" xmlns:ttm="http://www.w3.org/ns/ttml#metadata"
+ xmlns:ebutts="urn:ebu:tt:style" xml:lang="en" ttp:timeBase="media" xmlns:ebuttm="urn:ebu:tt:metadata" >
 	<head>
+		<metadata>
+			<ebuttm:documentMetadata>
+				<ebuttm:conformsToStandard>urn:ebu:tt:distribution:2014-01</ebuttm:conformsToStandard>
+				<ebuttm:conformsToStandard>http://www.w3.org/ns/ttml/profile/imsc1/text</ebuttm:conformsToStandard>
+			</ebuttm:documentMetadata>
+		</metadata>		
 		<styling>
             <style xml:id="baseStyle" tts:color="#FFFFFF"/>
             <style xml:id="blackBackground" tts:backgroundColor="#000000"/>


### PR DESCRIPTION
The test suites samples for line padding and multirow align have been drafted to be compatible with EBU-TT-D. They were not any more due to the addition of the ttp:profile attribute in PR #140. Therefore the indication of the profiles should be done as proposed in the spec using the ebuttm:conformsToStandard element.

Closes #148