### PR TITLE
Address line comments for issue-126 branch made by @nigelmegitt

### DIFF
--- a/spec/examples/image-example.xml
+++ b/spec/examples/image-example.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tt xml:lang="fr"
+    xmlns="http://www.w3.org/ns/ttml"
+    xmlns:ttm="http://www.w3.org/ns/ttml#metadata" 
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter" 
+    xmlns:smpte="http://www.smpte-ra.org/schemas/2052-1/2010/smpte-tt"
+    xmlns:itts="http://www.w3.org/ns/ttml/profile/imsc1#styling"
+    tts:extent="640px 480px"
+    ttp:frameRate="25"
+    ttp:profile="http://www.w3.org/ns/ttml/profile/imsc1/image">
+    
+    <head>
+        <layout>
+            <region xml:id="region1" tts:origin="120px 410px" tts:extent="240px 40px" tts:showBackground="whenActive"/>
+            <region xml:id="region2" tts:origin="120px 20px" tts:extent="240px 40px" tts:showBackground="whenActive"/>
+        </layout>
+    </head>
+    <body>
+        <div region="region1" begin="00:00:01:00" end="00:00:02:00" smpte:backgroundImage="1.png"/>
+        <div region="region1" begin="00:00:03:20" end="00:00:04:12" smpte:backgroundImage="2.png"/>
+        <div region="region2" itts:forcedDisplay="true" begin="00:00:03:20" end="00:00:04:12" smpte:backgroundImage="3.png"/>
+    </body>
+</tt>
+

--- a/spec/examples/text-and-ebuttd-example.xml
+++ b/spec/examples/text-and-ebuttd-example.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tt xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://www.w3.org/ns/ttml" xmlns:ttp="http://www.w3.org/ns/ttml#parameter"
+    xmlns:tts="http://www.w3.org/ns/ttml#styling" xmlns:ttm="http://www.w3.org/ns/ttml#metadata"
+    xmlns:ebutts="urn:ebu:tt:style" xml:lang="en" ttp:timeBase="media" xmlns:ebuttm="urn:ebu:tt:metadata" >
+    <head>
+        <metadata>
+            <ebuttm:documentMetadata>
+                <ebuttm:conformsToStandard>urn:ebu:tt:distribution:2014-01</ebuttm:conformsToStandard>
+                <ebuttm:conformsToStandard>http://www.w3.org/ns/ttml/profile/imsc1/text</ebuttm:conformsToStandard>
+            </ebuttm:documentMetadata>
+        </metadata>		
+        <styling>
+            <style xml:id="baseStyle" tts:color="#FFFFFF" tts:lineHeight="100%"/>
+            <style xml:id="blackBackground" tts:backgroundColor="#000000"/>
+            <style xml:id="greenBackground" tts:backgroundColor="#00FF00"/>
+            <style xml:id="startEnd" tts:textAlign="start" ebutts:multiRowAlign="end"/>
+            <style xml:id="centerStart" tts:textAlign="center" ebutts:multiRowAlign="start"/>
+        </styling>
+        <layout>
+            <region xml:id="area1" tts:origin="15% 10%" tts:extent="70% 20%" style="greenBackground" tts:displayAlign="center"/>
+            <region xml:id="area2" tts:origin="15% 70%" tts:extent="70% 20%" style="blackBackground" tts:displayAlign="center"/>
+        </layout>
+    </head>
+    <body>
+        <div style="baseStyle">			
+            <p xml:id="s1" region="area1" style="startEnd" begin="00:00:01" end="00:00:09">
+                multiRowAlign="end"<br/>textAlign="start"
+            </p>
+            <p xml:id="s2" region="area2" style="centerStart" begin="00:00:01" end="00:00:09">
+                multiRowAlign="start"<br/>textAlign="center"
+            </p>
+        </div>
+    </body>
+</tt>
+

--- a/spec/examples/text-and-smptett-example.xml
+++ b/spec/examples/text-and-smptett-example.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tt xml:lang="en" xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata" 
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter" ttp:profile="http://www.smpte-ra.org/schemas/2052-1/2010/profiles/smpte-tt-full"
+    xmlns:tts="http://www.w3.org/ns/ttml#styling" ttp:frameRate="24">
+    <head>
+        <layout>
+            <region xml:id="area1" tts:origin="10% 70%" tts:extent="80% 20%" tts:showBackground="whenActive" tts:backgroundColor="red" tts:displayAlign="center" tts:color="white"/>
+        </layout>
+    </head>
+    <body tts:lineHeight="100%">
+        <div>			
+            <p region="area1" begin="00:00:01.01" end="00:00:03">This should appear on frame 25.</p>
+            <p region="area1" begin="00:00:04" end="00:00:06">This should appear on frame 96.</p>
+            <p region="area1" begin="00:00:07.33" end="00:00:09">This should appear on frame 176.</p>
+        </div>
+    </body>
+</tt>
+

--- a/spec/examples/text-example.xml
+++ b/spec/examples/text-example.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tt xml:lang="en"
+    xmlns="http://www.w3.org/ns/ttml"
+    xmlns:ttm="http://www.w3.org/ns/ttml#metadata" 
+    xmlns:tts="http://www.w3.org/ns/ttml#styling"
+    xmlns:ttp="http://www.w3.org/ns/ttml#parameter" 
+    xmlns:ittp="http://www.w3.org/ns/ttml/profile/imsc1#parameter"
+    ittp:aspectRatio="4 3"
+    ttp:profile="http://www.w3.org/ns/ttml/profile/imsc1/text">
+    
+    <head>
+        <layout>
+            <region xml:id="area1" tts:origin="10% 10%" tts:extent="80% 10%" tts:backgroundColor="black" tts:displayAlign="center" tts:color="red"/>
+        </layout>
+    </head>
+    <body>
+        <div>
+            <p region="area1" begin="0s" end="6s">Lorem ipsum dolor sit amet.</p>
+        </div>
+    </body>
+</tt>

--- a/spec/ttml-ww-profiles.html
+++ b/spec/ttml-ww-profiles.html
@@ -3489,7 +3489,7 @@ be present on the <code>tt</code> element.</td>
 				<p>A document that conforms to [[!EBU-TT-D]] therefore generally also conforms to the Text Profile, with a few exceptions, including:
 					<ul>
 					<li>[[!EBU-TT-D]] does not constrain document complexity using an HRM;</li>
-					<li>[[!EBU-TT-D]] allows UTF-16 encoding in addition to UTF-8 encoding; and</li>
+					<li>[[!EBU-TT-D]] recommends use of UTF-8 encoding but allows alternate encodings; and</li>
 					<li>[[!EBU-TT-D]] does not constrain the number of <a data-lt="presented region">presented regions</a> in a given <a>intermediate synchronic document</a>.</li>
 					</ul>
 				</p>
@@ -3514,7 +3514,7 @@ be present on the <code>tt</code> element.</td>
 			&lt;/ebuttm:documentMetadata&gt;
 		&lt;/metadata&gt;		
 		&lt;styling&gt;
-            &lt;style xml:id=&quot;baseStyle&quot; tts:color=&quot;#FFFFFF&quot;/&gt;
+            &lt;style xml:id=&quot;baseStyle&quot; tts:color=&quot;#FFFFFF&quot; tts:lineHeight=&quot;100%&quot;/&gt;
             &lt;style xml:id=&quot;blackBackground&quot; tts:backgroundColor=&quot;#000000&quot;/&gt;
             &lt;style xml:id=&quot;greenBackground&quot; tts:backgroundColor=&quot;#00FF00&quot;/&gt;
 			&lt;style xml:id=&quot;startEnd&quot; tts:textAlign=&quot;start&quot; ebutts:multiRowAlign=&quot;end&quot;/&gt;
@@ -3525,7 +3525,7 @@ be present on the <code>tt</code> element.</td>
 			&lt;region xml:id=&quot;area2&quot; tts:origin=&quot;15% 70%&quot; tts:extent=&quot;70% 20%&quot; style=&quot;blackBackground&quot; tts:displayAlign=&quot;center&quot;/&gt;
 		&lt;/layout&gt;
 	&lt;/head&gt;
-	&lt;body tts:lineHeight=&quot;100%&quot;&gt;
+	&lt;body&gt;
 		&lt;div style=&quot;baseStyle&quot;&gt;			
 			&lt;p xml:id=&quot;s1&quot; region=&quot;area1&quot; style=&quot;startEnd&quot; begin=&quot;00:00:01&quot; end=&quot;00:00:09&quot;&gt;
 multiRowAlign=&quot;end&quot;&lt;br/&gt;textAlign=&quot;start&quot;
@@ -3572,18 +3572,16 @@ multiRowAlign=&quot;start&quot;&lt;br/&gt;textAlign=&quot;center&quot;
 			<section class='appendix'>
 				<h3>SMPTE-TT (SMPTE ST 2052-1)</h3>
 				
-				<p>[[!ST2052-1]] specifies the use of the DFXP Full Profile (see Appendix F.3 at [[!TTML1]]) suplemented by a number of extensions, including <code>http://www.smpte-ra.org/schemas/2052-1/2010/smpte-tt#image</code>.</p>
+				<p>[[!ST2052-1]] specifies the use of the DFXP Full Profile (see Appendix F.3 at [[!TTML1]]) supplemented by a number of extensions, including <code>http://www.smpte-ra.org/schemas/2052-1/2010/smpte-tt#image</code>.</p>
 				
 				<p>This specification defines practical constraints on [[!ST2052-1]], supplemented by a few extensions defined at <a href="#features-and-extensions"></a>. These constraints and extensions are intended to reflect industry practice.</p>
 				
 				<p>As a result, particular care is required when creating a document intended to be processed according to both [[!ST2052-1]] and Text Profile or Image Profile. In particular:
 					<ul>
 					
-					<li>in contrast to Text Profile and Image Profile, [[!ST2052-1]] allows a document that contains <code>smpte:backgroundImage</code> attribute to also contain <code>p</code>, <code>span</code>, <code>br</code> elements;</li>
+					<li>in contrast to Text Profile and Image Profile, [[!ST2052-1]] allows documents to contain both <code>smpte:backgroundImage</code> attributes and any of <code>p</code>, <code>span</code>, or <code>br</code> elements;</li>
 					
 					<li>Image Profile allows only a subset of the <code>http://www.smpte-ra.org/schemas/2052-1/2010/smpte-tt#image</code> extension;</li>
-					
-					<li>[[!ST2052-1]] allows a document that contains <code>smpte:backgroundImage</code> attribute to also contain <code>p</code>, <code>span</code>, <code>br</code> elements;</li>
 					
 					<li>[[!ST2052-1]] does not support the <code>#aspectRatio</code>, <code>#forcedDisplay</code>, 
 					<code>#linePadding</code> and <code>#multiRowAlign</code> extensions that impact presentation; and</li>


### PR DESCRIPTION
* Change EBU-TT-D encoding statement to remove specific reference to
UTF-16 and mention EBU-TT-D recommendation for UTF-8.
* Make EBU-TT-D example validate against EBU-TT-D schema by moving
`tts:lineHeight` specification from `<body>` to `"baseStyle" <style>`.
* Fix typo of supplemented
* Tighten up wording re SMPTE-TT constraints and remove redundant
bullet.