### PR TITLE
Add Security and Privacy section

### DIFF
--- a/imsc1/misc/tidy.cfg
+++ b/imsc1/misc/tidy.cfg
@@ -19,3 +19,4 @@ new-inline-tags: cfif, cfelse, math, mroot,
 new-blocklevel-tags: cfoutput, cfquery
 new-empty-tags: cfelse
 tidy-mark: false
+char-encoding: utf8

--- a/imsc1/spec/ttml-ww-profiles.html
+++ b/imsc1/spec/ttml-ww-profiles.html
@@ -4062,10 +4062,12 @@ y = topOffset * (1 - height/100)
     <h2>Privacy and Security Considerations</h2>
     
     <h3>TTML security</h3>
-    <p>In general the security and privacy considerations of [[!XML]] and [[!TTML1]]
-    apply to the <a>Text Profile</a> and <a>Image Profile</a> defined in this
-    specification, particularly in relation to document parsing. XML Entity
-    expansion is prohibited by TTML.</p>
+    <p>In general the security and privacy considerations of [[rfc3023]] and 
+    [[!TTML1]] apply, particularly in relation to document parsing. XML Entities
+    are excluded from the Reduced XML Infoset of TTML and are therefore not
+    considered part of conformant documents; nevertheless it would be prudent
+    for implementors to provide protection against recursive entity expansion or
+    prevent entity expansion altogether in processors.</p>
       
     <h3>Privacy of preference</h3>
     A user agent that selects, and causes to download or interpret a 
@@ -4081,12 +4083,12 @@ y = topOffset * (1 - height/100)
     <h3>Security and Privacy related to external images</h3>
     <p>The <a>Image Profile</a> includes a mechanism for referencing external
     images. A user agent that downloads external images during media playback
-    might indicate to the origin server the progress of the user's media 
+    indicates to the origin server the progress of the user's media 
     consumption. That is a small piece of information that in many cases is
     available via other mechanisms, for example by scripting or by monitoring
     streaming media requests.</p>
     <p>User agents that do not enforce cross origin policies when downloading
-    external images could expose such media progress information to other
+    external images expose such media progress information to other
     origins. This specification defines no APIs and makes no statement on how
     implementations are expected to obtain referenced images.</p>
   </section>

--- a/imsc1/spec/ttml-ww-profiles.html
+++ b/imsc1/spec/ttml-ww-profiles.html
@@ -4083,14 +4083,16 @@ y = topOffset * (1 - height/100)
     <h3>Security and Privacy related to external images</h3>
     <p>The <a>Image Profile</a> includes a mechanism for referencing external
     images. A user agent that downloads external images during media playback
-    indicates to the origin server the progress of the user's media 
-    consumption. That is a small piece of information that in many cases is
-    available via other mechanisms, for example by scripting or by monitoring
-    streaming media requests.</p>
+    indicates to the origin server of the images the progress of the user's media 
+    consumption. In many cases such media progress information is available to
+    the origin server of the media via other mechanisms, for example by 
+    scripting or by monitoring streaming media requests.</p>
     <p>User agents that do not enforce cross origin policies when downloading
-    external images expose such media progress information to other
-    origins. This specification defines no APIs and makes no statement on how
-    implementations are expected to obtain referenced images.</p>
+    external images expose such media progress information and potentially 
+    other user tracking information to other origins without the consent of the
+    web site serving the media and without the consent of the user. This 
+    specification defines no APIs and makes no statement on how implementations 
+    are expected to obtain referenced images.</p>
   </section>
 </body>
 </html>

--- a/imsc1/spec/ttml-ww-profiles.html
+++ b/imsc1/spec/ttml-ww-profiles.html
@@ -4057,5 +4057,38 @@ y = topOffset * (1 - height/100)
     <p>The editor also wishes to acknowledge Digital Entertainment Content Ecosystem (DECE) for contributing to the initial
     document for the Member Submission.</p>
   </section>
+  
+  <section class='appendix'>
+    <h2>Privacy and Security Considerations</h2>
+    
+    <h3>TTML security</h3>
+    <p>In general the security and privacy considerations of [[!XML]] and [[!TTML1]]
+    apply to the <a>Text Profile</a> and <a>Image Profile</a> defined in this
+    specification, particularly in relation to document parsing. XML Entity
+    expansion is prohibited by TTML.</p>
+      
+    <h3>Privacy of preference</h3>
+    A user agent that selects, and causes to download or interpret a 
+    <a>Document Instance</a>, might indicate to the origin server that the user 
+    has a need for 
+    captions or subtitles, and also the language preference of the user for 
+    captions or subtitles. That is a (small) piece of information about the 
+    user. However, the offering of a caption file, and the choice whether to 
+    retrieve and consume it, are really characteristics of the format or 
+    protocol which makes the offer (e.g. the HTML element), rather than of the 
+    caption format itself. [[HTML]]
+    
+    <h3>Security and Privacy related to external images</h3>
+    <p>The <a>Image Profile</a> includes a mechanism for referencing external
+    images. A user agent that downloads external images during media playback
+    might indicate to the origin server the progress of the user's media 
+    consumption. That is a small piece of information that in many cases is
+    available via other mechanisms, for example by scripting or by monitoring
+    streaming media requests.</p>
+    <p>User agents that do not enforce cross origin policies when downloading
+    external images could expose such media progress information to other
+    origins. This specification defines no APIs and makes no statement on how
+    implementations are expected to obtain referenced images.</p>
+  </section>
 </body>
 </html>

--- a/imsc1/spec/ttml-ww-profiles.html
+++ b/imsc1/spec/ttml-ww-profiles.html
@@ -82,17 +82,19 @@ table.syntax { border: 0px solid black; width: 85%; border-collapse: collapse }
 
   <section id='sotd'>
     <p>The Timed Text Working Group intends to recommend transition of this document to Candidate Recommendation and is offering
-    this Working Draft for a public review period ending on 7 May 2017. This revision of the document is designed such
-    that <a data-lt="processor">Processors</a> and <a data-lt="document instance">document instances</a> that conform to the
-    <a href="http://www.w3.org/TR/2016/REC-ttml-imsc1-20160421/">Recommendation dated 21 April 2016</a> also conform to this
-    revision. As a result, review should focus on the modifications made since the <a href=
+    this Working Draft for a public review period ending on 7 May 2017. This revision of the document is designed such that
+    <a data-lt="processor">Processors</a> and <a data-lt="document instance">document instances</a> that conform to the <a href=
+    "http://www.w3.org/TR/2016/REC-ttml-imsc1-20160421/">Recommendation dated 21 April 2016</a> also conform to this revision. As a
+    result, review should focus on the modifications made since the <a href=
     "http://www.w3.org/TR/2016/REC-ttml-imsc1-20160421/">Recommendation dated 21 April 2016</a>, including the <a href=
     "#ittp-activeArea"></a> and <a href="#itts-fillLineGap"></a> features.</p>
-		
-		<p>A list of the substantive changes applied since the initial Working Draft is found at <a href="substantive-changes-summary.txt">substantive-changes-summary.txt</a>.</p>
-		
-		<p>For convenience, a complete diff between this version and the <a href=
-    "http://www.w3.org/TR/2016/REC-ttml-imsc1-20160421/">Recommendation dated 21 April 2016</a> is found at <a href="diff.html">diff.html</a>.</p>
+
+    <p>A list of the substantive changes applied since the initial Working Draft is found at <a href=
+    "substantive-changes-summary.txt">substantive-changes-summary.txt</a>.</p>
+
+    <p>For convenience, a complete diff between this version and the <a href=
+    "http://www.w3.org/TR/2016/REC-ttml-imsc1-20160421/">Recommendation dated 21 April 2016</a> is found at <a href=
+    "diff.html">diff.html</a>.</p>
   </section>
 
   <section id='scope'>
@@ -4057,42 +4059,34 @@ y = topOffset * (1 - height/100)
     <p>The editor also wishes to acknowledge Digital Entertainment Content Ecosystem (DECE) for contributing to the initial
     document for the Member Submission.</p>
   </section>
-  
+
   <section class='appendix'>
-    <h2>Privacy and Security Considerations</h2>
-    
+    <h2>Privacy and Security Considerations (non-normative)</h2>
+
     <h3>TTML security</h3>
-    <p>In general the security and privacy considerations of [[rfc3023]] and 
-    [[!TTML1]] apply, particularly in relation to document parsing. XML Entities
-    are excluded from the Reduced XML Infoset of TTML and are therefore not
-    considered part of conformant documents; nevertheless it would be prudent
-    for implementors to provide protection against recursive entity expansion or
-    prevent entity expansion altogether in processors.</p>
-      
-    <h3>Privacy of preference</h3>
-    A user agent that selects, and causes to download or interpret a 
-    <a>Document Instance</a>, might indicate to the origin server that the user 
-    has a need for 
-    captions or subtitles, and also the language preference of the user for 
-    captions or subtitles. That is a (small) piece of information about the 
-    user. However, the offering of a caption file, and the choice whether to 
-    retrieve and consume it, are really characteristics of the format or 
-    protocol which makes the offer (e.g. the HTML element), rather than of the 
-    caption format itself. [[HTML]]
-    
+
+    <p>The security and privacy considerations of [[rfc3023]] and [[!TTML1]] apply, particularly in relation to document parsing.
+    XML Entities are excluded from the Reduced XML Infoset of TTML and are therefore not considered part of <a data-lt=
+    "Document Instance">Document Instances</a>; nevertheless implementations are encouraged to provide protection against recursive
+    entity expansion or prevent entity expansion altogether in processors.</p>
+
+    <h3>Privacy of preference</h3>A user agent that selects, and causes to download or interpret a <a>Document Instance</a>, might
+    indicate to the origin server that the user has a need for captions or subtitles, and also the language preference of the user
+    for captions or subtitles. That is a small piece of information about the user. However, the offering of a <a>Document
+    Instance</a>, and the choice whether to retrieve and consume it, are characteristics of the application that makes the offer
+    (e.g. a web application based on [[HTML]]), rather than of the <a>Document Instance</a> itself.
+
     <h3>Security and Privacy related to external images</h3>
-    <p>The <a>Image Profile</a> includes a mechanism for referencing external
-    images. A user agent that downloads external images during media playback
-    indicates to the origin server of the images the progress of the user's media 
-    consumption. In many cases such media progress information is available to
-    the origin server of the media via other mechanisms, for example by 
-    scripting or by monitoring streaming media requests.</p>
-    <p>User agents that do not enforce cross origin policies when downloading
-    external images expose such media progress information and potentially 
-    other user tracking information to other origins without the consent of the
-    web site serving the media and without the consent of the user. This 
-    specification defines no APIs and makes no statement on how implementations 
-    are expected to obtain referenced images.</p>
+
+    <p>The <a>Image Profile</a> includes a mechanism for referencing external images. A user agent that downloads external images
+    during media playback indicates to the origin server of the images the progress of the user's media consumption. In many cases
+    such media progress information is available to the origin server of the media via other mechanisms, for example by scripting
+    or by monitoring streaming media requests.</p>
+
+    <p>User agents that do not enforce cross origin policies when downloading external images expose such media progress
+    information and potentially other user tracking information to other origins without the consent of the web site serving the
+    media and without the consent of the user. This specification defines no APIs and makes no statement on how implementations are
+    expected to obtain referenced images.</p>
   </section>
 </body>
 </html>


### PR DESCRIPTION
Fix #219.

* Reference TTML and XML security
* Mention that XML Entity Expansion is prohibited
* Include slightly edited version of the draft Privacy of Preference
section from WebVTT (credit @dwsinger and @zcorpan) which also applies
here.
* Include Security and Privacy related to Images..