### PR TITLE
Attempt to make PR preview work

### DIFF
--- a/.pr-preview.json
+++ b/.pr-preview.json
@@ -1,4 +1,4 @@
 {
-    "src_file": "index.html",
+    "src_file": "imsc1/spec/ttml-ww-profiles.html",
     "type": "respec"
 }


### PR DESCRIPTION
Specify the path to the spec file rather than leaving as the default index.html, which does not correspond to a file in the repo.