### PR TITLE
Permit CSS font matching and font-face mapping

### DIFF
--- a/imsc1/spec/ttml-ww-profiles.html
+++ b/imsc1/spec/ttml-ww-profiles.html
@@ -3286,6 +3286,57 @@ y = topOffset * (1 - height/100)
  
         <p>All <code>source</code> elements that are children of a <code>font</code> element SHALL reference an <a>external data resource</a>.</p>
 
+        <p><a>Processors</a> MAY use the [[css-fonts-3]] §5 font
+          matching algorithm for associating a font with a run of text.</p>
+
+        <p>Fonts MAY be mapped to <a>font resources</a> using
+          the [[css-fonts-3]] §4.1 <code>@font-face</code> rule, where the 
+          attributes of the <code>font</code> element or its descendents
+          are mapped, with appropriate value translation,
+          to CSS descriptors according to
+          the following table:</p>
+
+          <table class="simple">
+            <thead>
+              <tr></tr>
+              <th>TTML2 <code>font</code> element</th>
+                <th>CSS descriptor</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>family</code> attribute</td>
+  
+                <td><code>font-family</code></td>
+              </tr>
+
+              <tr>
+                <td><code>source</code> child element <code>src</code> attribute</td>
+                <td><code>src</code></td>
+              </tr>
+
+              <tr>
+                <td><code>range</code> attribute</td>
+
+                <td><code>unicode-range</code></td>
+              </tr>
+  
+              <tr>
+                <td><code>style</code> attribute</td>
+
+                <td><code>font-style</code></td>
+              </tr>
+
+              <tr>
+                <td><code>weight</code> attribute</td>
+
+                <td><code>font-weight</code></td>
+              </tr>
+
+            </tbody>
+          </table>
+  
+
         <aside class="note">A <a>font resource</a> can reference an <a>external data resource</a> with a type not supported at
         <a href="#section-font-resources"></a>, in which case a sibling <a>external data resources</a> with a supported type can also be specified
         for fallback processing.</aside>
@@ -3310,6 +3361,17 @@ y = topOffset * (1 - height/100)
 </pre>
       </aside>
 
+      <aside class="note">
+        The [[TTML2]] semantic for selecting the font for
+        rendering any given set of code points is based on [[XSL11]] §7.9.3's
+        <code>auto</code> semantic, which is implementation dependent.
+        It is possible that the implemented font selection algorithm uses a
+        different font for presentation than [[TTML2]]'s line height computation
+        algorithm would select, which could lead to unexpected results.
+        It is possible to implement authoring tools that check the metrics of
+        referenced font resoures and highlight any potential mismatches in
+        line height.
+      </aside>
       </section>
 
       <section id="text-fontFamily-generic">

--- a/imsc1/spec/ttml-ww-profiles.html
+++ b/imsc1/spec/ttml-ww-profiles.html
@@ -3286,11 +3286,11 @@ y = topOffset * (1 - height/100)
  
         <p>All <code>source</code> elements that are children of a <code>font</code> element SHALL reference an <a>external data resource</a>.</p>
 
-        <p><a>Processors</a> MAY use the [[css-fonts-3]] §5 font
+        <p>A <a>Processor</a> MAY use the [[css-fonts-3]] §5 font
           matching algorithm for associating a font with a run of text.</p>
 
-        <p>Fonts MAY be mapped to <a>font resources</a> using
-          the [[css-fonts-3]] §4.1 <code>@font-face</code> rule, where the 
+        <p>A <a>Processor</a> MAY use the
+          [[css-fonts-3]] §4.1 <code>@font-face</code> rule to map fonts to <a>font resources</a>, where the 
           attributes of the <code>font</code> element or its descendents
           are mapped, with appropriate value translation,
           to CSS descriptors according to

--- a/imsc1/spec/ttml-ww-profiles.html
+++ b/imsc1/spec/ttml-ww-profiles.html
@@ -3286,57 +3286,6 @@ y = topOffset * (1 - height/100)
  
         <p>All <code>source</code> elements that are children of a <code>font</code> element SHALL reference an <a>external data resource</a>.</p>
 
-        <p>A <a>Processor</a> MAY use the [[css-fonts-3]] §5 font
-          matching algorithm for associating a font with a run of text.</p>
-
-        <p>A <a>Processor</a> MAY use the
-          [[css-fonts-3]] §4.1 <code>@font-face</code> rule to map fonts to <a>font resources</a>, where the 
-          attributes of the <code>font</code> element or its descendents
-          are mapped, with appropriate value translation,
-          to CSS descriptors according to
-          the following table:</p>
-
-          <table class="simple">
-            <thead>
-              <tr></tr>
-              <th>TTML2 <code>font</code> element</th>
-                <th>CSS descriptor</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td><code>family</code> attribute</td>
-  
-                <td><code>font-family</code></td>
-              </tr>
-
-              <tr>
-                <td><code>source</code> child element <code>src</code> attribute</td>
-                <td><code>src</code></td>
-              </tr>
-
-              <tr>
-                <td><code>range</code> attribute</td>
-
-                <td><code>unicode-range</code></td>
-              </tr>
-  
-              <tr>
-                <td><code>style</code> attribute</td>
-
-                <td><code>font-style</code></td>
-              </tr>
-
-              <tr>
-                <td><code>weight</code> attribute</td>
-
-                <td><code>font-weight</code></td>
-              </tr>
-
-            </tbody>
-          </table>
-  
-
         <aside class="note">A <a>font resource</a> can reference an <a>external data resource</a> with a type not supported at
         <a href="#section-font-resources"></a>, in which case a sibling <a>external data resources</a> with a supported type can also be specified
         for fallback processing.</aside>
@@ -3361,6 +3310,9 @@ y = topOffset * (1 - height/100)
 </pre>
       </aside>
 
+      <p>A <a>Processor</a> MAY use the [[css-fonts-3]] §5 font
+        matching algorithm for associating a font with a run of text.</p>
+
       <aside class="note">
         When the computed value of <code>tts:fontSelectionStrategy</code> is
         <code>"auto"</code> as required by this specification,
@@ -3369,11 +3321,9 @@ y = topOffset * (1 - height/100)
         The implemented font selection algorithm can therefore use a
         different font for presentation than [[TTML2]]'s line height computation
         algorithm selects, which could lead to unexpected results.
-        It is possible to implement authoring tools that check the metrics of
-        referenced font resources and highlight any potential mismatches in
-        line height.
       </aside>
-      </section>
+
+    </section>
 
       <section id="text-fontFamily-generic">
         <h4><code>#fontFamily-generic</code></h4>

--- a/imsc1/spec/ttml-ww-profiles.html
+++ b/imsc1/spec/ttml-ww-profiles.html
@@ -3362,14 +3362,15 @@ y = topOffset * (1 - height/100)
       </aside>
 
       <aside class="note">
-        The [[TTML2]] semantic for selecting the font for
-        rendering any given set of code points is based on [[XSL11]] §7.9.3's
-        <code>auto</code> semantic, which is implementation dependent.
-        It is possible that the implemented font selection algorithm uses a
+        When the computed value of <code>tts:fontSelectionStrategy</code> is
+        <code>"auto"</code> as required by this specification,
+        the algorithm for associating a font with a run of text
+        is implementation dependent.
+        The implemented font selection algorithm can therefore use a
         different font for presentation than [[TTML2]]'s line height computation
-        algorithm would select, which could lead to unexpected results.
+        algorithm selects, which could lead to unexpected results.
         It is possible to implement authoring tools that check the metrics of
-        referenced font resoures and highlight any potential mismatches in
+        referenced font resources and highlight any potential mismatches in
         line height.
       </aside>
       </section>


### PR DESCRIPTION
Closes #516 :

* State that processors may use CSS 3 font matching algorithm.
* State that fonts may be mapped to font resources using the `@font-face` rule.
* Tabulate mapping of `font` element attributes and child element attributes to CSS descriptors
* Note the potential discrepancy between line height computation font selection and rendering font selection.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/imsc/pull/517.html" title="Last updated on Feb 13, 2020, 4:03 PM UTC (349ed01)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/imsc/517/53faae4...349ed01.html" title="Last updated on Feb 13, 2020, 4:03 PM UTC (349ed01)">Diff</a>