### PR TITLE
fixed reference from html5 to html (from whatwg)

### DIFF
--- a/imsc1/spec/ttml-ww-profiles.html
+++ b/imsc1/spec/ttml-ww-profiles.html
@@ -2787,7 +2787,7 @@ ittp:progressivelyDecodable
         <pre class='example' data-include='examples/altText-example.xml' data-include-format='text'>
 </pre>
 
-        <p class='note'>In contrast to the common use of <code>alt</code> attributes in [[HTML5]], the <code>ittm:altText</code>
+        <p class='note'>In contrast to the common use of <code>alt</code> attributes in [[HTML]], the <code>ittm:altText</code>
         attribute content is not intended to be displayed in place of the element if the element is not loaded. The
         <code>ittm:altText</code> attribute content can however be read and used by assistive technologies.</p>
       </section>
@@ -4615,7 +4615,7 @@ y = topOffset * (1 - height/100)
       for all non-text content. In the context of this specification, this <a>Text Alternative</a> is intended primarily to support
       users of the subtitles who cannot see images. Since the images of an <a>Image Profile</a> <a>Document Instance</a> usually
       represent subtitle or caption text, the guidelines for authoring text equivalent strings given at <span class='sec-no'>Images
-      of text</span> of [[HTML5]] are appropriate.</p>
+      of text</span> of [[HTML]] are appropriate.</p>
 
       <p>Thus, for each subtitle in an <a>Image Profile</a> <a>Document Instance</a>, a text equivalent content in a <a>Text
       Profile</a> <a>Document Instance</a> SHOULD be written so that it conveys all essential content and fulfills the same


### PR DESCRIPTION
for comment at https://github.com/w3c/transitions/issues/234#issuecomment-599529863


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: write EPROTO 140222018242432:error:1407742E:SSL routines:SSL23_GET_SERVER_HELLO:tlsv1 alert protocol version:../deps/openssl/openssl/ssl/s23_clnt.c:772:
 :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 16, 2020, 1:37 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fw3c%2Fimsc%2Fpull%2F528%2F4b72015.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fhimorin%2Fimsc%2Fpull%2F528.html)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/imsc%23528.)._
</details>
