### PR TITLE
Improved "Latest Recommendation" link in the document header

### DIFF
--- a/imsc1/spec/ttml-ww-profiles.html
+++ b/imsc1/spec/ttml-ww-profiles.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset='utf-8'>
 
-  <title>TTML Profiles for Internet Media Subtitles and Captions 1.0.1 (IMSC1) (Link corrected 9 April 2020)</title>
+  <title>TTML Profiles for Internet Media Subtitles and Captions 1.0.1 (IMSC1)</title>
   <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async="" class='remove'>
 </script>
   <script class='remove'>

--- a/imsc1/spec/ttml-ww-profiles.html
+++ b/imsc1/spec/ttml-ww-profiles.html
@@ -19,7 +19,7 @@ var respecConfig = {
                 ,   previousPublishDate: "2018-02-27"
                 ,   shortName:    "ttml-imsc1.0.1"
                 ,   otherLinks: [{
-                          key: 'Latest IMSC1 recommendation',
+                          key: 'Latest IMSC recommendation',
                           data: [{
                               href: 'https://www.w3.org/TR/ttml-imsc/rec'
                           }]
@@ -84,7 +84,7 @@ table.syntax { border: 0px solid black; width: 85%; border-collapse: collapse }
   </section>
 
   <section id='sotd'>
-    <p class="advisement">
+    <p class="note">
       Status Update (April 2020): The link to the latest IMSC1 Recommendation in the header was fixed in-place on April 9 2020: they were pointing to TTML IMSC 1.0.1, and were fixed to link to the latest Recommendation of TTML IMSC.
     </p>
     <p>A list of non-substantive changes applied since the <a href=

--- a/imsc1/spec/ttml-ww-profiles.html
+++ b/imsc1/spec/ttml-ww-profiles.html
@@ -85,7 +85,7 @@ table.syntax { border: 0px solid black; width: 85%; border-collapse: collapse }
 
   <section id='sotd'>
     <p class="note">
-      Status Update (April 2020): The link to the latest IMSC1 Recommendation in the header was fixed in-place on April 9 2020: they were pointing to TTML IMSC 1.0.1, and were fixed to link to the latest Recommendation of TTML IMSC.
+      Status Update (9 April 2020): In the document header, the "Latest IMSC1 Recommendation" link (pointing to the specific "TTML Profiles for Internet Media Subtitles and Captions 1.0.1" Recommendation) was replaced by a "Latest IMSC Recommendation" link pointing to the most recently published Recommendation in the "TTML Profiles for Internet Media Subtitles and Captions" family of Recommendations.
     </p>
     <p>A list of non-substantive changes applied since the <a href=
     "https://www.w3.org/TR/2018/PR-ttml-imsc1.0.1-20180227/">Proposed Recommendation</a> is found at <a href=

--- a/imsc1/spec/ttml-ww-profiles.html
+++ b/imsc1/spec/ttml-ww-profiles.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset='utf-8'>
 
-  <title>TTML Profiles for Internet Media Subtitles and Captions 1.0.1 (IMSC1)</title>
+  <title>TTML Profiles for Internet Media Subtitles and Captions 1.0.1 (IMSC1) (Link corrected 9 April 2020)</title>
   <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async="" class='remove'>
 </script>
   <script class='remove'>
@@ -21,7 +21,7 @@ var respecConfig = {
                 ,   otherLinks: [{
                           key: 'Latest IMSC1 recommendation',
                           data: [{
-                            href: 'https://www.w3.org/TR/ttml-imsc1/'
+                              href: 'https://www.w3.org/TR/ttml-imsc/rec'
                           }]
                         }]
                   ,   editors: [{
@@ -84,6 +84,9 @@ table.syntax { border: 0px solid black; width: 85%; border-collapse: collapse }
   </section>
 
   <section id='sotd'>
+    <p class="advisement">
+      Status Update (April 2020): The link to the latest IMSC1 Recommendation in the header was fixed in-place on April 9 2020: they were pointing to TTML IMSC 1.0.1, and were fixed to link to the latest Recommendation of TTML IMSC.
+    </p>
     <p>A list of non-substantive changes applied since the <a href=
     "https://www.w3.org/TR/2018/PR-ttml-imsc1.0.1-20180227/">Proposed Recommendation</a> is found at <a href=
     "changes-summary.txt">changes-summary.txt</a>. For convenience, a diff is offered at the <a href=


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/imsc/pull/537.html" title="Last updated on Apr 7, 2020, 4:32 PM UTC (1eecd1e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/imsc/537/b847d80...himorin:1eecd1e.html" title="Last updated on Apr 7, 2020, 4:32 PM UTC (1eecd1e)">Diff</a>