### PR TITLE
updated prEnd and publishDate to final one

### DIFF
--- a/imsc1/spec/ttml-ww-profiles.html
+++ b/imsc1/spec/ttml-ww-profiles.html
@@ -17,8 +17,8 @@ var respecConfig = {
                     specStatus:   "PR"
                 ,   previousMaturity: "CR"
                 ,   crEnd: "2020-05-05"
-                ,   prEnd: "2020-07-11"
-                ,   publishDate: "2020-06-11"
+                ,   prEnd: "2020-07-14"
+                ,   publishDate: "2020-06-16"
                 /*,   errata: "http://www.w3.org/2018/11/ttml-imsc1.1-errata.html"*/
                 ,   implementationReportURI: "https://www.w3.org/wiki/TimedText/IMSC1_2_Implementation_Report"
                 ,   sotdAfterWGinfo: "true"


### PR DESCRIPTION
Updated with dates fixed.
ref. https://w3c.github.io/spec-releases/milestones/?pr=2020-06-16