### PR TITLE
use 'group' instead of 'wg', 'wgURI', 'wgPatentURI'

### DIFF
--- a/imsc1/spec/ttml-ww-profiles.html
+++ b/imsc1/spec/ttml-ww-profiles.html
@@ -35,10 +35,8 @@ var respecConfig = {
                           w3cid:  "57073",
                           mailto: "pal@sandflow.com"
                         }]
-                  ,   wg: "Timed Text Working Group"
-                  ,   wgURI: "https://www.w3.org/AudioVideo/TT/"
+                  ,   group: "timed-text"
                   ,   wgPublicList: "public-tt"
-                  ,   wgPatentURI: "https://www.w3.org/2004/01/pp-impl/34314/status"
                   ,   subjectPrefix: "[imsc]"
                   ,   edDraftURI: "https://w3c.github.io/imsc/imsc1/spec/ttml-ww-profiles.html"
                   ,   github: {

--- a/imsc1/spec/ttml-ww-profiles.html
+++ b/imsc1/spec/ttml-ww-profiles.html
@@ -10,7 +10,7 @@ figure img {
       height: auto;
     }
   </style>
-  <script src='https://www.w3.org/Tools/respec/respec-w3c-common' async="" class='remove'>
+  <script src='https://www.w3.org/Tools/respec/respec-w3c' async="" class='remove'>
 </script>
   <script class='remove'>
 var respecConfig = {


### PR DESCRIPTION
(for future use)
From [recent respec update](https://lists.w3.org/Archives/Public/spec-prod/2020JulSep/0002.html), replace 'wg', 'wgURI', 'wgPatentURI' with 'group': 

> ## `group` configuration option
> 
> With a new configuration option — “group”, you can specify a “shortname” for the WG/CG and let ReSpec figure out the details for you. The wg, wgId, wgURI, and wgPatentURI options are deprecated in favour of “group”.

'timed-text' is from [list](https://respec.org/w3c/groups/)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/imsc/pull/563.html" title="Last updated on Aug 6, 2020, 3:29 PM UTC (0ff0ca6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/imsc/563/fd1ca89...himorin:0ff0ca6.html" title="Last updated on Aug 6, 2020, 3:29 PM UTC (0ff0ca6)">Diff</a>