### PR TITLE
Removing DESTINATION from GHAction wolkflow of streamlined publication

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -22,7 +22,6 @@ jobs:
         with:
           TOOLCHAIN: respec
           SOURCE: imsc1/spec/ttml-ww-profiles.html
-          DESTINATION: Overview.html
           W3C_ECHIDNA_TOKEN: ${{ secrets.W3C_TR_TOKEN }}
           W3C_WG_DECISION_URL: https://www.w3.org/2025/07/17-tt-minutes.html#d940
           W3C_BUILD_OVERRIDE: |


### PR DESCRIPTION
I hope this could be the fix...

Looking around [spec-prod examples](https://github.com/w3c/spec-prod/blob/main/docs/examples.md) and some other live GHaction configurations (and their actions' log files), it seems

- Some actions with multiple spec source build echidna material starting from files at OUTPUTS_BUILD structure of env provided to `Deploy to W3C` section, which could be started from subdirectory of root in built assets
- [DESTINATION](https://github.com/w3c/spec-prod/blob/main/docs/options.md#destination) states that other assets related to spec file will be copied into directory specified by DESTINATION, but structure in`Artifact download URL` from Action log does not align with this statement (should be a bug or some issue in spec-prod?? - not sure)