### PR TITLE
Add DAPT conformance signaling

### DIFF
--- a/imsc1/spec/ttml-ww-profiles.html
+++ b/imsc1/spec/ttml-ww-profiles.html
@@ -4038,7 +4038,7 @@ y = topOffset * (1 - height/100)
       <p><a href="#resources-constraints"></a> prohibits embedded audio
         within <a>Document Instances</a>.
         A <a data-cite="dapt#dfn-dapt-document">DAPT document</a> that uses this feature
-        can therefore not be a conformant <a>Document Instance</a>.</p>
+        is therefore not a conformant <a>Document Instance</a>.</p>
 
       <section id="dapt-signaling">
         <h4>Signaling conformance to DAPT</h4>
@@ -4065,16 +4065,16 @@ y = topOffset * (1 - height/100)
             data can be used to apply styling or to insert content 
             that indicates changes of speaker, such as prefixing text with
             commonly used change of speaker symbols, or with the
-            name of the speaker.</li>
+            name of the speaker;</li>
           <li>representation data (i.e. metadata that
             <a data-cite="dapt#dfn-content-descriptor">describes what content</a> in
             the <a>Related Video Object</a> the text content represents) can be
             used to filter or select sub-sets of the text content, for example
-            to include or exclude non-dialogue sound captions.</li>
+            to include or exclude non-dialogue sound captions;</li>
           <li>language and <a data-cite="dapt#dfn-text-language-source">Text language source</a>
             metadata can be used to generate
             translation subtitle documents including <a data-cite="dapt#dfn-text">Text</a>
-            that has been translated into the desired language.</li>
+            that has been translated into the desired language;</li>
           <li>language and <a data-cite="dapt#dfn-text-language-source">Text language source</a>
             metadata can be used to identify
             subtitles that are <a data-cite="dapt#dfn-translation">Translations</a>,


### PR DESCRIPTION
Closes #622 

* Explain use of multiple values in `ttp:contentProfiles`
* Add DAPT to the list of compatible specifications in the overview
* Add a DAPT interoperability section to appendix I including constraints and compatibility notes
* Describe how DAPT metadata can be used in an IMSC context

Can be improved later to use definitions exported from DAPT, but directly cites non-exported definitions for the time being.