### PR TITLE
updated for REC publication

### DIFF
--- a/imsc1/spec/ttml-ww-profiles.html
+++ b/imsc1/spec/ttml-ww-profiles.html
@@ -15,13 +15,12 @@ figure img {
   <script class='remove'>
 var respecConfig = {
                     specStatus:   "ED"
-                ,   previousMaturity: "CR"
+                ,   previousMaturity: "REC"
                 ,   crEnd: "2026-01-15"
                 ,   implementationReportURI: "https://www.w3.org/wiki/TimedText/IMSC1_3_Implementation_Report"
                 //,   prEnd: "2020-07-14"
                 //,   publishDate: "2025-12-18"
-                /*,   errata: "http://www.w3.org/2020/08/ttml-imsc1.2-errata.html"
-                ,   sotdAfterWGinfo: "true"*/
+                ,   errata: "https://www.w3.org/2026/05/ttml-imsc1.3-errata/"
                 //,   previousPublishDate: "2020-08-04"
                 ,   shortName:    "ttml-imsc1.3"
                 ,   otherLinks: [{

--- a/imsc1/spec/ttml-ww-profiles.html
+++ b/imsc1/spec/ttml-ww-profiles.html
@@ -14,12 +14,12 @@ figure img {
 </script>
   <script class='remove'>
 var respecConfig = {
-                    specStatus:   "ED"
-                ,   previousMaturity: "REC"
+                    specStatus:   "REC"
+                ,   previousMaturity: "CRD"
                 ,   crEnd: "2026-01-15"
                 ,   implementationReportURI: "https://www.w3.org/wiki/TimedText/IMSC1_3_Implementation_Report"
                 //,   prEnd: "2020-07-14"
-                //,   publishDate: "2025-12-18"
+                ,   publishDate: "2026-05-21"
                 ,   errata: "https://www.w3.org/2026/05/ttml-imsc1.3-errata/"
                 //,   previousPublishDate: "2020-08-04"
                 ,   shortName:    "ttml-imsc1.3"


### PR DESCRIPTION
* added url for errata
* set previous as REC
* removed `sotdAfterWGinfo` which has no longer used


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/imsc/pull/643.html" title="Last updated on May 20, 2026, 2:10 PM UTC (c3afb89)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/imsc/643/0865eb7...c3afb89.html" title="Last updated on May 20, 2026, 2:10 PM UTC (c3afb89)">Diff</a>